### PR TITLE
feat: support grpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ Solder is a comprehensive Solana backend framework that abstracts away the compl
 - Node.js >= 18
 - npm, pnpm, or yarn
 - PostgreSQL database
-- Solana RPC endpoint (optional: defaults to public mainnet RPC) with **WebSocket** connection. You would need **BOTH** URLs.
+- Solana RPC endpoint (optional: defaults to public mainnet RPC)
+- **Realtime streaming endpoint** (choose one):
+  - **Yellowstone gRPC endpoint** (recommended): Provides low-latency block streaming with better reliability
+  - **WebSocket endpoint**: Must support `blockSubscribe` RPC method (many providers don't support this)
 - Google Cloud Project with KMS (optional: only if using cloud wallets)
 
 ### Solder App Setup
@@ -465,12 +468,25 @@ The `Indexer` class is the core component for monitoring Solana blockchain event
 ```typescript
 import { Indexer } from "@solder-build/core";
 
+// Example with gRPC streaming (recommended)
 const indexer = new Indexer({
   startBlock: 300000000, // Starting slot number
   rpcUrl: process.env.RPC_URL, // Solana RPC endpoint
   databaseUrl: process.env.DATABASE_URL, // PostgreSQL connection string
   cursorKey: "my-indexer", // Unique identifier for this indexer
   enableUIProgress: true, // Enable real-time progress UI
+  grpcUrl: process.env.GRPC_URL, // Yellowstone gRPC endpoint
+  grpcToken: process.env.GRPC_TOKEN, // Optional: gRPC authentication token
+});
+
+// Example with WebSocket streaming (requires blockSubscribe support)
+const indexerWS = new Indexer({
+  startBlock: 300000000,
+  rpcUrl: process.env.RPC_URL,
+  databaseUrl: process.env.DATABASE_URL,
+  cursorKey: "my-indexer",
+  enableUIProgress: true,
+  wsUrl: process.env.WS_URL, // WebSocket endpoint (must support blockSubscribe)
 });
 ```
 
@@ -482,6 +498,33 @@ const indexer = new Indexer({
 | `rpcUrl`      | `string` | Yes      | Solana RPC endpoint URL                                 |
 | `databaseUrl` | `string` | No       | PostgreSQL connection string (required for persistence) |
 | `cursorKey`   | `string` | No       | Unique key for cursor storage (defaults to "default")   |
+| `enableUIProgress` | `boolean` | No    | Enable real-time progress UI (defaults to `false`)      |
+| `grpcUrl`     | `string` | Yes*     | Yellowstone gRPC endpoint for streaming (required if `wsUrl` not provided) |
+| `grpcToken`   | `string` | No       | Optional authentication token for gRPC endpoint          |
+| `wsUrl`       | `string` | Yes*     | WebSocket endpoint for streaming (required if `grpcUrl` not provided) |
+| `logger`      | `Logger` | No       | Custom logger instance (defaults to console logger)      |
+
+\* **Either `grpcUrl` or `wsUrl` must be provided, but not both.**
+
+### ⚠️ WebSocket Requirements and Limitations
+
+**Important:** The `wsUrl` option requires a WebSocket endpoint that supports the `blockSubscribe` RPC method. Many RPC providers (including Helius) do not support this method, which will cause the indexer to fail with a "Method not found" error.
+
+**If WebSocket initialization fails, the indexer will stop immediately with an error message.** There is no automatic fallback to HTTP polling.
+
+**Recommendation:** Use `grpcUrl` with a Yellowstone gRPC endpoint for more reliable streaming. Yellowstone gRPC provides:
+- Lower latency than WebSocket
+- More efficient data handling
+- Better reliability and reconnection handling
+- Direct block data without additional RPC calls
+
+**Example error when WebSocket doesn't support `blockSubscribe`:**
+
+```
+[ERROR] Failed to initialize websocket channel: Error: Method not found
+```
+
+If you encounter this error, switch to using `grpcUrl` instead of `wsUrl`.
 
 ### Registering Event Handlers
 
@@ -562,7 +605,7 @@ When `enableUIProgress: true` is set, Solder provides a real-time terminal UI th
 - **Indexing Stats**: Real-time event processing statistics with RPS (requests per second)
 - **Event Table**: Live view of processed events with counts and performance metrics
 - **Progress Bar**: Visual progress indicator with ETA calculations
-- **Health Monitoring**: Database, WebSocket, and RPC connection status
+- **Health Monitoring**: Database, realtime stream (gRPC/WebSocket), and RPC connection status
 
 The progress UI automatically updates in place, providing a clean development experience without cluttering your terminal output.
 
@@ -596,6 +639,11 @@ export const initializeIndexer = async () => {
     databaseUrl: process.env.DATABASE_URL,
     cursorKey: "pump-fun-indexer",
     enableUIProgress: true,
+    // Use gRPC for reliable streaming (recommended)
+    grpcUrl: process.env.GRPC_URL,
+    grpcToken: process.env.GRPC_TOKEN, // Optional
+    // Or use WebSocket (only if your provider supports blockSubscribe)
+    // wsUrl: process.env.WS_URL,
   });
 
   await indexer.onEvent({

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,6 +45,7 @@
     "@solana/kit": "^4.0.0",
     "@solana/rpc": "^4.0.0",
     "@solana/web3.js": "^1.98.4",
+    "@triton-one/yellowstone-grpc": "^4.0.2",
     "ansi-escapes": "^7.1.1",
     "bs58": "^6.0.0",
     "drizzle-orm": "^0.44.6",

--- a/packages/core/src/indexer/indexer.ts
+++ b/packages/core/src/indexer/indexer.ts
@@ -2,7 +2,7 @@ import { RpcClient } from "../rpc/rpc";
 import type { BlockTransactionInfo, BlockInfoResult, EventFilterOptions, InstructionFilterOptions } from "../types/block";
 import { DecodedEvent, isLegacyIdl } from "../idl/idl";
 import { ProgressUiController } from "../ui/progress";
-import { CursorStore, type StoredBlock, type StoredEvent } from "./db";
+import { CursorStore, type StoredBlock } from "./db";
 import { drizzle, NodePgDatabase } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import type { AnchorIdl } from "../idl/idl-types";
@@ -19,6 +19,12 @@ import type {
 } from "./types/config.types";
 import { parallelMap } from "../utils/async";
 import { buildBlockInfoResult } from "../utils/block";
+import YellowstoneGrpcClient, {
+  CommitmentLevel,
+  txEncode,
+  type SubscribeUpdate,
+  type SubscribeUpdateBlock,
+} from "@triton-one/yellowstone-grpc";
 import {
   WebSocketChannel,
   type WebSocketSubscription,
@@ -33,6 +39,8 @@ type BlockProcessingContext = {
   hasEventHandlers: boolean;
   hasTransactionHandlers: boolean;
 };
+
+type YellowstoneStream = Awaited<ReturnType<YellowstoneGrpcClient["subscribeOnce"]>>;
 
 export class Indexer {
   private readonly HISTORICAL_CHUNK_SIZE = 50;
@@ -51,6 +59,9 @@ export class Indexer {
     | (NodePgDatabase<Record<string, never>> & { $client: Pool })
     | null = null;
   private uiShutdown?: () => void;
+  private grpcClient?: YellowstoneGrpcClient;
+  private grpcStream?: YellowstoneStream;
+  private grpcHealthy = false;
   private websocketChannel?: WebSocketChannel;
   private websocketSubscription?: WebSocketSubscription<BlockNotificationPayload>;
   private wsHealthy = false;
@@ -58,7 +69,9 @@ export class Indexer {
   private firstRealtimeSlot: number | null = null; // Anchor point for historical sync
   private historicalSyncComplete = false;
   private progressUi?: ProgressUiController;
-  private wsUrl: string;
+  private wsUrl?: string;
+  private grpcUrl?: string;
+  private grpcToken?: string;
   private logger: Logger;
 
   constructor(config: IndexerConfig) {
@@ -69,15 +82,27 @@ export class Indexer {
       enableUIProgress = false,
       databaseUrl,
       wsUrl,
+      grpcUrl,
+      grpcToken,
       logger = defaultLogger,
     } = config;
+
+    if (wsUrl && grpcUrl) {
+      throw new Error("Provide either wsUrl or grpcUrl, not both.");
+    }
 
     this.rpcClient = new RpcClient({ endpoint: rpcUrl });
     this.currentSlot = startBlock;
     this.cursorKey = cursorKey;
     this.enableUIProgress = enableUIProgress;
     this.wsUrl = wsUrl;
+    this.grpcUrl = grpcUrl;
+    this.grpcToken = grpcToken;
     this.logger = logger;
+
+    if (!this.wsUrl && !this.grpcUrl) {
+      throw new Error("Indexer requires either wsUrl or grpcUrl for realtime streaming");
+    }
 
     const pool = new Pool({
       connectionString: databaseUrl,
@@ -304,15 +329,18 @@ export class Indexer {
       if (this.latestRealtimeSlot !== null) {
         this.progressUi.recordRealtimeSlot(this.latestRealtimeSlot);
       }
-      this.uiShutdown = ProgressUiController.setup(() =>
-        this.progressUi!.buildState({
+      this.uiShutdown = ProgressUiController.setup(() => {
+        // Compute stream health/active dynamically on each refresh
+        const streamHealthy = this.grpcUrl ? this.grpcHealthy : this.wsHealthy;
+        const streamActive = this.grpcUrl ? !!this.grpcStream : !!this.websocketChannel;
+        return this.progressUi!.buildState({
           isRunning: this.isRunning,
           currentSlot: this.currentSlot,
           hasDatabase: this.db !== null,
-          wsHealthy: this.wsHealthy,
-          websocketActive: !!this.websocketChannel,
-        }),
-      );
+          streamHealthy,
+          streamActive,
+        });
+      });
     } else {
       this.progressUi = undefined;
     }
@@ -334,16 +362,9 @@ export class Indexer {
       );
     }
 
-    await this.initializeRealtimeSync().catch((error) => {
-      this.logger.error("Failed to initialize websocket channel, falling back to HTTP polling:", error);
-      return null;
-    });
+    await this.initializeRealtimeSync()
 
-    // Wait for first realtime block to establish historical target
-    if (this.websocketSubscription) {
-      this.logger.info("⏳ Waiting for first realtime block to establish sync boundary...");
-      await this.waitForFirstRealtimeBlock();
-    }
+    await this.waitForFirstRealtimeBlock();
 
     // Historical sync target: up to (firstRealtimeSlot - 1) or current chain tip
     const historicalTarget = this.firstRealtimeSlot 
@@ -381,6 +402,15 @@ export class Indexer {
       this.uiShutdown();
       this.uiShutdown = undefined;
     }
+
+    if (this.grpcStream) {
+      this.grpcStream.removeAllListeners?.();
+      this.grpcStream.cancel();
+      this.grpcStream = undefined;
+    }
+
+    this.grpcClient = undefined;
+    this.grpcHealthy = false;
 
     if (this.websocketSubscription) {
       this.websocketSubscription.removeAllListeners();
@@ -424,6 +454,74 @@ export class Indexer {
         resolve();
       }, 10_000);
     });
+  }
+
+  /**
+   * Handle SubscribeUpdate messages emitted by Yellowstone.
+   */
+  private handleGrpcUpdate(update: SubscribeUpdate): void {
+    if (update.block?.slot) {
+      const payload = this.convertGrpcBlockToPayload(update.block);
+      if (payload) {
+        this.processBlock(payload);
+      }
+      return;
+    }
+  }
+
+  private convertGrpcBlockToPayload(block: SubscribeUpdateBlock): BlockNotificationPayload | null {
+    const slot = Number(block.slot);
+
+    const blockTime = block.blockTime?.timestamp ? Number(block.blockTime.timestamp) : undefined;
+    const blockHeight = block.blockHeight?.blockHeight
+      ? Number(block.blockHeight.blockHeight)
+      : undefined;
+
+    type GrpcDecodedTransaction = {
+      transaction: unknown;
+      meta: unknown;
+    };
+
+    const transactions = block.transactions
+      .map<GrpcDecodedTransaction | null>((transactionInfo) => {
+        try {
+          const encoded = txEncode.encode(
+            transactionInfo,
+            txEncode.encoding.Json,
+            0,
+            false,
+          );
+
+          if (!encoded) {
+            return null;
+          }
+
+          return {
+            transaction: encoded.transaction,
+            meta: encoded.meta ?? null,
+          };
+        } catch (error) {
+          this.logger.error("[Yellowstone] Failed to decode transaction from gRPC block update:", error);
+          return null;
+        }
+      })
+      .filter((txn): txn is GrpcDecodedTransaction => txn !== null);
+
+    return {
+      context: { slot },
+      value: {
+        slot,
+        block: {
+          blockhash: block.blockhash,
+          previousBlockhash: block.parentBlockhash,
+          parentSlot: Number(block.parentSlot) || 0,
+          blockTime,
+          blockHeight,
+          transactions,
+        },
+        err: null,
+      },
+    };
   }
 
   /**
@@ -833,6 +931,70 @@ export class Indexer {
   }
 
   private async initializeRealtimeSync(): Promise<void> {
+    if (this.grpcUrl) {
+      await this.initializeGrpcSync();
+      return;
+    } else if (this.wsUrl) {
+      await this.initializeWebsocketSync();
+      return;
+    }
+
+    throw new Error("Indexer requires either grpcUrl or wsUrl for realtime streaming");
+  }
+
+  private async initializeGrpcSync(): Promise<void> {
+    if (!this.grpcUrl) {
+      throw new Error("grpcUrl is required for Yellowstone streaming");
+    }
+
+    this.grpcClient = new YellowstoneGrpcClient(this.grpcUrl, this.grpcToken, {
+      "grpc.keepalive_time_ms": 20_000,
+    });
+
+    const registeredProgramIds = this.getRegisteredProgramIds();
+
+    const stream = await this.grpcClient.subscribeOnce(
+      {}, // accounts
+      {}, // slots
+      {}, // transactions
+      {}, // transactionsStatus
+      {}, // entry
+      {
+        solderBlocks: {
+          accountInclude: registeredProgramIds.length > 0 ? registeredProgramIds : [],
+          includeTransactions: true,
+          includeAccounts: false,
+          includeEntries: false,
+        },
+      },
+      {}, // blocksMeta
+      CommitmentLevel.CONFIRMED,
+      [], // accountsDataSlice
+    );
+
+    this.grpcStream = stream;
+    this.grpcHealthy = true;
+
+    this.logger.info(`Connected to Yellowstone gRPC stream at ${this.grpcUrl} (subscribed to blocks)`);
+
+    stream.on("data", (update) => this.handleGrpcUpdate(update));
+
+    stream.on("error", (error) => {
+      this.grpcHealthy = false;
+      this.logger.error("[Yellowstone] stream error:", error);
+    });
+
+    stream.on("end", () => {
+      this.grpcHealthy = false;
+      this.logger.warn("[Yellowstone] stream ended");
+    });
+  }
+
+  private async initializeWebsocketSync(): Promise<void> {
+    if (!this.wsUrl) {
+      throw new Error("wsUrl is required for WebSocket streaming");
+    }
+
     this.websocketChannel = new WebSocketChannel({
       nodeUrl: this.wsUrl,
       autoReconnect: true,

--- a/packages/core/src/indexer/indexer.ts
+++ b/packages/core/src/indexer/indexer.ts
@@ -91,6 +91,10 @@ export class Indexer {
       throw new Error("Provide either wsUrl or grpcUrl, not both.");
     }
 
+    if (!wsUrl && !grpcUrl) {
+      throw new Error("Indexer requires either wsUrl or grpcUrl for realtime streaming");
+    }
+
     this.rpcClient = new RpcClient({ endpoint: rpcUrl });
     this.currentSlot = startBlock;
     this.cursorKey = cursorKey;
@@ -99,10 +103,6 @@ export class Indexer {
     this.grpcUrl = grpcUrl;
     this.grpcToken = grpcToken;
     this.logger = logger;
-
-    if (!this.wsUrl && !this.grpcUrl) {
-      throw new Error("Indexer requires either wsUrl or grpcUrl for realtime streaming");
-    }
 
     const pool = new Pool({
       connectionString: databaseUrl,

--- a/packages/core/src/indexer/types/config.types.ts
+++ b/packages/core/src/indexer/types/config.types.ts
@@ -12,15 +12,26 @@ export interface WebsocketConfig {
   url: string;
 }
 
-export interface IndexerConfig {
+interface BaseIndexerConfig {
   startBlock: number;
   rpcUrl: string;
-  wsUrl: string;
-  databaseUrl: string; 
-  cursorKey?: string; 
+  databaseUrl: string;
+  cursorKey?: string;
   enableUIProgress?: boolean;
   logger?: Logger;
 }
+
+export type IndexerConfig =
+  | (BaseIndexerConfig & {
+      wsUrl: string;
+      grpcUrl?: never;
+      grpcToken?: never;
+    })
+  | (BaseIndexerConfig & {
+      wsUrl?: never;
+      grpcUrl: string;
+      grpcToken?: string;
+    });
 
 export interface RegisteredProgram {
   programId: string;

--- a/packages/core/src/ui/progress.ts
+++ b/packages/core/src/ui/progress.ts
@@ -29,7 +29,7 @@ export type ProgressUiState = {
   };
   health: {
     database: boolean;
-    ws: boolean;
+    stream: boolean;
     rpc: boolean;
   };
 };
@@ -47,8 +47,8 @@ export type ProgressUiSource = {
   isRunning: boolean;
   currentSlot: number;
   hasDatabase: boolean;
-  wsHealthy: boolean;
-  websocketActive: boolean;
+  streamHealthy: boolean;
+  streamActive: boolean;
 };
 
 export class ProgressUiController {
@@ -111,7 +111,7 @@ export class ProgressUiController {
     const currentHistoricalSlot = this.state.historicalSlot ?? source.currentSlot;
     const percent = this.calculateProgress(currentHistoricalSlot);
     const eta = this.calculateETA(rps, percent, currentHistoricalSlot);
-    const websocketConnected = source.websocketActive ? source.wsHealthy : false;
+    const streamConnected = source.streamActive ? source.streamHealthy : false;
 
     return {
       status: source.isRunning ? 'Running' : 'Stopped',
@@ -134,12 +134,12 @@ export class ProgressUiController {
         },
         realtime: {
           slot: this.realtimeSlot,
-          connected: websocketConnected,
+          connected: streamConnected,
         },
       },
       health: {
         database: source.hasDatabase,
-        ws: websocketConnected,
+        stream: streamConnected,
         rpc: true,
       },
     };
@@ -211,8 +211,10 @@ export class ProgressUiController {
         detail: `${ProgressUiController.formatPercentage(state.percent)} @ ${state.streams.historical.rps.toFixed(1)} rps`,
       },
       {
-        pipeline: 'Realtime WebSocket',
-        status: state.streams.realtime.connected ? pc.greenBright('Connected') : pc.redBright('Disconnected'),
+        pipeline: 'Realtime Stream',
+        status: state.streams.realtime.connected
+          ? pc.greenBright('Connected')
+          : pc.redBright('Disconnected'),
         slot: state.streams.realtime.slot ?? '-',
         detail: state.streams.realtime.connected ? 'streaming' : 'waiting',
       },
@@ -250,8 +252,8 @@ export class ProgressUiController {
         '│ RPC      │ ' +
         (state.health.rpc ? pc.greenBright('✓') : pc.redBright('✗')) +
         ' │\n' +
-        '│ WebSocket│ ' +
-        (state.health.ws ? pc.greenBright('✓') : pc.redBright('✗')) +
+      '│ Stream   │ ' +
+        (state.health.stream ? pc.greenBright('✓') : pc.redBright('✗')) +
         ' │',
     );
     lines.push('');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       '@solana/web3.js':
         specifier: ^1.98.4
         version: 1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@triton-one/yellowstone-grpc':
+        specifier: ^4.0.2
+        version: 4.0.2
       ansi-escapes:
         specifier: ^7.1.1
         version: 7.1.1
@@ -1278,6 +1281,10 @@ packages:
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
+
+  '@triton-one/yellowstone-grpc@4.0.2':
+    resolution: {integrity: sha512-RsHNbLz6zCU3OpQRBqKWcXqDDOKj1nxc/78LIt9kZWBU2kfYeFs7361eUpYE9Q3+BizjpCLF6BX9G1OitD76bw==}
+    engines: {node: '>=20.18.0'}
 
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
@@ -4157,6 +4164,10 @@ snapshots:
       tslib: 2.8.1
 
   '@tootallnate/once@2.0.0': {}
+
+  '@triton-one/yellowstone-grpc@4.0.2':
+    dependencies:
+      '@grpc/grpc-js': 1.14.0
 
   '@types/connect@3.4.38':
     dependencies:


### PR DESCRIPTION
# Add Yellowstone gRPC Streaming Support to Indexer

## Summary

This PR adds support for Yellowstone gRPC streaming as an alternative to WebSocket for real-time block data. The indexer now supports both transport methods (mutually exclusive) and processes block data directly from the gRPC stream without additional RPC calls.

## Problem

The previous WebSocket implementation relied on the `blockSubscribe` RPC method, which many RPC providers (including Helius) do not support. This caused indexers to fail with "Method not found" errors, limiting compatibility with various Solana RPC endpoints.

## Solution

- **Added Yellowstone gRPC streaming support** using `@triton-one/yellowstone-grpc`
- **Updated `IndexerConfig`** to accept either `grpcUrl` or `wsUrl` (mutually exclusive)

## Changes

### Core Changes

- **`packages/core/src/indexer/indexer.ts`**:
  - Added `grpcClient`, `grpcStream`, and `grpcHealthy` properties
  - Implemented `initializeGrpcSync()` using `subscribeOnce` for block subscriptions
  - Added `handleGrpcUpdate()` to process incoming gRPC block updates
  - Added `convertGrpcBlockToPayload()` to transform gRPC blocks into `BlockNotificationPayload`
  - Updated `initializeRealtimeSync()` to support both gRPC and WebSocket
  - Modified progress UI to dynamically determine stream health based on active transport

- **`packages/core/src/indexer/types/config.types.ts`**:
  - Updated `IndexerConfig` to a union type supporting either `wsUrl` or `grpcUrl`
  - Added `grpcToken` as optional authentication for gRPC endpoints
  - Enforced mutual exclusivity: cannot provide both `wsUrl` and `grpcUrl`

- **`packages/core/src/ui/progress.ts`**:
  - Renamed `wsHealthy` → `streamHealthy` and `websocketActive` → `streamActive`
  - Updated UI labels from "WebSocket" to "Realtime Stream" for transport-agnostic display

- **`packages/core/src/examples/simple-indexer.ts`**:
  - Updated example to use `grpcUrl` and `grpcToken` instead of `wsUrl`

## Benefits

1. **Better Compatibility**: Works with RPC providers that don't support `blockSubscribe`
2. **Lower Latency**: Yellowstone gRPC provides lower latency than WebSocket
3. **More Efficient**: Direct block data from stream without additional RPC calls
4. **Better Reliability**: Improved reconnection handling and stream management
5. **Backward Compatible**: Existing WebSocket implementations continue to work
