### PR TITLE
Support emit macro on anchor on solder core

### DIFF
--- a/packages/core/src/idl/idl.ts
+++ b/packages/core/src/idl/idl.ts
@@ -258,8 +258,6 @@ export function parseEventsFromLogs(
           const decoded = decodeEventFromLogData(base64Data, currentProgram, idl);
           if (decoded) {
             events.push({ programId: currentProgram, event: decoded });
-          } else {
-            truncated = true;
           }
         }
       }

--- a/packages/core/src/idl/idl.ts
+++ b/packages/core/src/idl/idl.ts
@@ -161,3 +161,110 @@ export function decodeLegacyEvent(
   // Reuse existing decodeEvent since Borsh encoding is the same
   return decodeEvent(data, programId, idl as any);
 }
+
+/**
+ * Decode an event from base64-encoded log data (emit! macro format).
+ * The emit! macro logs events via sol_log_data with format: "Program data: <base64>"
+ * The base64 data contains: [8-byte discriminator][borsh-encoded event data]
+ */
+export function decodeEventFromLogData(
+  base64Data: string,
+  programId: string,
+  idl?: AnchorIdl,
+): DecodedEvent | null {
+  if (!idl) return null;
+  
+  try {
+    const eventCoder = getEventCoder(idl);
+    if (!eventCoder) return null;
+
+    // The log data is already base64 encoded and includes the discriminator
+    const decoded = eventCoder.decode(base64Data);
+    
+    if (!decoded) return null;
+    if (typeof decoded.name === "string") {
+      return {
+        contract: programId,
+        name: decoded.name,
+        type: "event",
+        data: decoded.data,
+      };
+    }
+    return null;
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Parse events from transaction log messages.
+ * Looks for "Program data:" entries which are emitted by Anchor's emit! macro.
+ * 
+ * Log format when emit! is used:
+ * - "Program <program_id> invoke [depth]"
+ * - ... other logs ...
+ * - "Program data: <base64_encoded_event>"
+ * - "Program <program_id> consumed X compute units"
+ * - "Program <program_id> success"
+ * 
+ * Returns events and whether logs appear to be truncated.
+ */
+export function parseEventsFromLogs(
+  logMessages: string[] | null | undefined,
+  programIdls: Map<string, AnchorIdl>,
+): { events: Array<{ programId: string; event: DecodedEvent }>; truncated: boolean } {
+  const events: Array<{ programId: string; event: DecodedEvent }> = [];
+  let truncated = false;
+  
+  if (!logMessages || logMessages.length === 0) {
+    return { events, truncated };
+  }
+
+  // Track the current program context from invoke/success logs
+  const programStack: string[] = [];
+  
+  for (const log of logMessages) {
+    // Check for log truncation indicator
+    if (log === "Log truncated") {
+      truncated = true;
+      continue;
+    }
+    
+    // Track program invocations to know which program emitted the event
+    const invokeMatch = log.match(/^Program (\w+) invoke \[\d+\]$/);
+    if (invokeMatch && invokeMatch[1]) {
+      programStack.push(invokeMatch[1]);
+      continue;
+    }
+    
+    const successMatch = log.match(/^Program (\w+) (success|failed)/);
+    if (successMatch && successMatch[1]) {
+      const completedProgram = successMatch[1];
+      const lastIndex = programStack.lastIndexOf(completedProgram);
+      if (lastIndex !== -1) {
+        programStack.splice(lastIndex, 1);
+      }
+      continue;
+    }
+    
+    const dataMatch = log.match(/^Program data: (.+)$/);
+    if (dataMatch && dataMatch[1]) {
+      const base64Data = dataMatch[1];
+      const currentProgram = programStack[programStack.length - 1];
+      
+      if (currentProgram) {
+        const idl = programIdls.get(currentProgram);
+        if (idl) {
+          const decoded = decodeEventFromLogData(base64Data, currentProgram, idl);
+          if (decoded) {
+            events.push({ programId: currentProgram, event: decoded });
+          } else {
+            truncated = true;
+          }
+        }
+      }
+    }
+  }
+  
+  return { events, truncated };
+}

--- a/packages/core/src/types/block.ts
+++ b/packages/core/src/types/block.ts
@@ -6,10 +6,19 @@ export type InstructionInfo = {
   parsed: unknown;
 };
 
+/**
+ * Source of the event:
+ * - "cpi": Event emitted via emit_cpi! macro (instruction data)
+ * - "log": Event emitted via emit! macro (program logs)
+ */
+export type EventSource = "cpi" | "log";
+
 export type EventInfo = {
   index: number;
   programId: string;
   event: DecodedEvent;
+  /** Source of the event - "cpi" for emit_cpi! or "log" for emit! */
+  source: EventSource;
 };
 
 export type BlockTransactionInfo = {

--- a/packages/core/src/utils/block.ts
+++ b/packages/core/src/utils/block.ts
@@ -8,7 +8,7 @@ import {
 } from "@solana/web3.js";
 import { createSolanaRpc } from "@solana/rpc";
 import { fromLegacyPublicKey } from "@solana/compat";
-import { decodeEvent, decodeInstruction } from "../idl/idl";
+import { decodeEvent, decodeInstruction, parseEventsFromLogs } from "../idl/idl";
 import type {
   BlockInfoResult,
   BlockTransactionInfo,
@@ -81,18 +81,49 @@ export function buildBlockTransactionsFromParsedBlock({
     let events: EventInfo[] = [];
 
     if (includeEvents && eventFilter && hasTxnMessage) {
-      events = collectWith<EventInfo>(
+      // 1. Collect events from CPI instructions (emit_cpi! macro)
+      const cpiEvents = collectWith<EventInfo>(
         { transaction: txn.transaction as ParsedTransaction, meta: txn.meta },
         eventFilter,
         ({ index, programId, instr }) => {
           if (isPartiallyDecodedInstruction(instr)) {
             const programIdl = eventFilter.programIdls?.get(programId);
             const decoded = decodeEvent(instr.data, programId, programIdl);
-            return decoded ? { index, programId, event: decoded } : null;
+            return decoded ? { index, programId, event: decoded, source: "cpi" as const } : null;
           }
           return null;
         },
       );
+
+      // 2. Collect events from program logs (emit! macro)
+      const logMessages = (txn.meta as ParsedTransactionMeta & { logMessages?: string[] })?.logMessages;
+      const { events: logEvents, truncated } = parseEventsFromLogs(
+        logMessages,
+        eventFilter.programIdls ?? new Map(),
+      );
+
+      if (truncated) {
+        console.warn(
+          `[solder/indexer] ⚠️  Log truncation detected in transaction ${signature ?? "unknown"} at slot ${slot}. ` +
+          `Events emitted via Anchor's emit!() macro may have been lost. ` +
+          `Consider migrating to emit_cpi!() for more reliable event indexing.`
+        );
+      }
+
+      const logEventInfos: EventInfo[] = logEvents
+        .filter(({ programId }) => 
+          eventFilter.programIds.length === 0 || eventFilter.programIds.includes(programId)
+        )
+        .map(({ programId, event }, idx) => ({
+          // Use negative index to distinguish from CPI events
+          index: -(idx + 1),
+          programId,
+          event,
+          source: "log" as const,
+        }));
+
+      // Combine both sources (CPI events first, then log events)
+      events = [...cpiEvents, ...logEventInfos];
     }
 
     let instructions: InstructionInfo[] = [];


### PR DESCRIPTION
## Description

- Log that's truncated will clearly say "Log truncated" we detect whether or not the event can be parse and show user warning


## Demo

```
  "Program log: Instruction: TransferChecked",
  "Log truncated",
  "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success"
]
==============DEBUG NOBODY===============
[solder/indexer] ⚠️  Log truncation detected in transaction 32ghcMC5XUfx9ZRJQTaK8hB3ruLF9MBX4oEGPwXNVqZ1fb48JA1wQ82Qwn2a3deZj5y2PBrbnSdfCVbVwCmg2uyr at slot 398266820. Events emitted via Anchor's emit!() macro may have been lost. Consider migrating to emit_cpi!() for more reliable event indexing.
==============DEBUG DepositEvent===============
{
  params: {
    depositor: PublicKey [PublicKey(H4nUSnLeSchwa5S1Cacfrpu8gnucbhCqTRoK46m4Ejgr)] {
      _bn: <BN: eeb3266263ddfd8ab03fb198e0892856220c31103137bf41ef4af98122967067>
    },
    token: null,
    amount: <BN: 15f5c040>,
    id: [
      124, 160,  50, 227, 203, 129,  60, 126,
      111, 239,  61, 110,  68, 197, 150,  49,
      152, 139, 202, 205,   1, 132, 199,   1,
      121,  93,  95, 227,  50,   6, 193,  55
    ]
  },
  timestamp: '2026-02-05T17:22:38.000Z',
  transaction: {
    hash: 'JSh3VXtv8DMG5keo9z3v2USj64kzpT3hWiMMdMS1hzWf7iyB52F97YLdjHXuiBVi3TenEqdznwMQZ4sdNkRAHfb',
    slot: 398266820,
    blockTime: 1770312158
  },
  programId: '99vQwtBwYtrqqD9YSXbdum3KBdxPAVxYTaQ3cfnJSrN2',
  eventName: 'DepositEvent'
}
==============DEBUG DepositEvent===============
```